### PR TITLE
Update CMakeLists.txt for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
 
 # define project name, version
-project(PSEMolDyn VERSION 0.0.1)
+project(PSEMolDyn VERSION 0.0.1 LANGUAGES CXX)
+
+# Finds the xerces-c library on your system
+# on linux: apt install libxerces-c-dev
+# on macOS: brew install xerces-c
+find_package(XercesC REQUIRED)
 
 # let ccmake and cmake-gui offer the default build type options
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebInfo;MinSizeRel")
@@ -22,7 +27,9 @@ file(GLOB_RECURSE MY_SRC
 # create make target
 add_executable(MolSim ${MY_SRC})
 
-# set cxx standard. You may raise this if you want.
+# You may raise the C++ standard if you want
+# Note, the bundled libxsd uses std::auto_ptr which was deprecated in C++11 and removed in C++17
+# Hence, some compilers (e.g. Apple Clang) refuse to compile with C++17, but e.g. not GNU GCC
 target_compile_features(MolSim
         PRIVATE
             cxx_std_17
@@ -38,7 +45,7 @@ target_include_directories(MolSim
 target_link_libraries(MolSim
         # stuff that is used in headers and source files
         PUBLIC
-            xerces-c
+            XercesC::XercesC
 )
 
 # activate all compiler warnings. Clean up your code :P


### PR DESCRIPTION
# Changelog

- Improve the finding of `libxerces-c` by employing `find_package(..)`, which works cross-platform
  - add some hints on how to install `libxerces-c` (e.g., either via `apt` or `brew`)
- ~Decrease C++ standard to `C++14` due to out-of-date bundled `libxsd`~
  - GNU GCC compiles fine with C++17 (also on macOS)
  - Apple Clang does **not** compile with C++17
  - This **is actually the desired** behavior in this case since the bundled library contains usages of `std::auto_ptr`. However, this feature was [removed in C++17](https://en.cppreference.com/w/cpp/memory/auto_ptr). So, GNU GCC compiles code that is actually not compliant with the standard.


**Update 26.05.2025**

I would suggest keeping C++17/ the teaching code as-is with the annotation that `libxsd`'s C++17 Compilation is actually not compliant. This way, on macOS, compilation is at least possible with GNU GCC while maintaining C++17 (even though it's with a flaw).
Compiling `xsd` with C++14 is not possible since it's a header library. This requires a more fundamental update.